### PR TITLE
2.0.2

### DIFF
--- a/Framer Inventory.sketchplugin/Contents/Sketch/actions/actionFactory.cocoascript
+++ b/Framer Inventory.sketchplugin/Contents/Sketch/actions/actionFactory.cocoascript
@@ -195,7 +195,10 @@ FramerInventory.organiseSelection = function(userSelection) {
 		FramerInventory.analyseMobile(frame.width)
 	}
 	
-	var cleanedSelection = FramerInventory.cleanSelection(userSelection)
+	var cleanedTypes = FramerInventory.cleanTypes(userSelection)
+	
+	
+	var cleanedSelection = FramerInventory.cleanSelection(cleanedTypes)
 	// if (showLog) { log("Cleaned selection: " + cleanedSelection.count() + " -> " + cleanedSelection) }
 	
 	var queue = FramerInventory.configureQueue(artboards, cleanedSelection)
@@ -208,10 +211,28 @@ FramerInventory.organiseSelection = function(userSelection) {
 	// if (showLog) { log("Duplicates cleaned: " + merged) }
 	
 	var newSelection = FramerInventory.composeSelection(merged, cleanedSelection)
-	// if (showLog) { log("Composed: " + newSelection) }
+	if (showLog) { log("Composed: " + newSelection) }
 	
 	return newSelection
 }
+
+
+FramerInventory.cleanTypes = function(userSelection) {
+	var newSelection = NSMutableArray.new()
+	
+	for (var i = 0; i < userSelection.count(); i++) {
+		var current = [userSelection objectAtIndex:i]
+		var type = [current className]
+		
+		if (type == "MSArtboardGroup" || type == "MSSliceLayer") { ; }
+		else {
+			newSelection = newSelection.arrayByAddingObjectsFromArray(NSArray.arrayWithObjects(current, nil))
+		}
+	}
+	
+	return newSelection
+}
+
 
 // skip layers with duplicated names from selection
 FramerInventory.cleanSelection = function(userSelection) {
@@ -530,4 +551,5 @@ FramerInventory.showDoneMessage = function() {
 		[currentDocument showMessage:"Done"]
 		FramerInventory.removePage(exportPageName)
 	}
+	if (showLog) { log("Completed") }
 }

--- a/Framer Inventory.sketchplugin/Contents/Sketch/inventory/classes/layer.cocoascript
+++ b/Framer Inventory.sketchplugin/Contents/Sketch/inventory/classes/layer.cocoascript
@@ -210,11 +210,6 @@ Layer.prototype.generateFramerTitle = function(imageRequired) {
 		titleShadows.push(shadowColor[1])
 	}
 	titleState.shadows = [titleShadows]
-	// if (titleShadows[4] != nil && titleShadows[5] != nil) { ; }
-	// else {
-		// if (titleShadows[4] != nil) { this.returnShadowOpacity(titleShadows[4]) }
-		// else { this.returnShadowHex(titleShadows[5]) }
-	// }
 
 	
 	var titleBorders = []
@@ -296,7 +291,8 @@ Layer.prototype.generateFramerStates = function() {
 
 		var stateDescription = this.describeState(currentState, imageRequired)
 		
-		statesDescriptions.push(stateDescription)
+		// if layer description has all properties
+		if (stateDescription != "") { statesDescriptions.push(stateDescription) }
 		statesNames.push(currentState.stateName)
 		
 		FramerInventory.addStateName(currentState.stateName)

--- a/Framer Inventory.sketchplugin/Contents/Sketch/inventory/getters/get-place.cocoascript
+++ b/Framer Inventory.sketchplugin/Contents/Sketch/inventory/getters/get-place.cocoascript
@@ -24,6 +24,12 @@ function getPosition(layer, type, isStillExportable) {
 
 
 var getPlaceImage = function(layer) {
+	
+	if (layer == nil) { 
+		if (showLog) { log("WARNING: Nil layer") }
+		return [100, 100, 0, 0]
+	}
+	
 	var currentPage = findParentPage(layer)
 	var parentArtboard = findParentArtboard(layer)
 	var parentRect = [parentArtboard absoluteRect]
@@ -41,6 +47,7 @@ var getPlaceImage = function(layer) {
 	
 	// normalize layer for export
 	[layer_copy setRotation: 0]
+	
 	if ([[[layer_copy style] contextSettings] opacity] == 0) {
 		[[[layer_copy style] contextSettings] setOpacity:(1.0)]
 	}


### PR DESCRIPTION
1) Fixed extra markable layers:
- ignore artboards
- ignore slices

2) Fixed empty switchInstant error
Can occur then layer’s description is the same as state, so state will
become empty and states.length will be > 1.
