### PR TITLE
Fix invalid manifest.json

### DIFF
--- a/Framer Inventory.sketchplugin/Contents/Sketch/manifest.json
+++ b/Framer Inventory.sketchplugin/Contents/Sketch/manifest.json
@@ -62,7 +62,7 @@
 		         "items": [
 				 	"choose-settings",
 					"choose-remove-export-page"
-		         ],
+		         ]
 		  }
       ]
     }


### PR DESCRIPTION
Sketchpacks Registry only parses valid `manifest.json` files. We'd like to keep your plugins' info in our registry up-to-date.

Fixing this minor bug will allow:
* Sketchpacks for macOS users to see accurate and up-to-date information for your plugin
* Sketchpacks Relay will serve your updates and published releases near real-time
* Sketchpacks for macOS users will be able to auto-update your plugins to the latest release

```
Error: Parse error on line 65:
..."		         ],		  }      ]    }}
---------------------^
Expecting 'STRING'
```